### PR TITLE
Add Docker quick-start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 /fxplanet/media
 /fxplanet/settings_local.py
 /env
+/.idea
+
+# Stay safe and not commit any of these
+*.gz
+*.zip
+*.sql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.4-jessie
+
+# Dependencies. All for Pillow
+RUN apt-get update && apt-get install -y xvfb \
+    git wget python-numpy python-scipy netpbm \
+    python-qt4 ghostscript libffi-dev libjpeg-turbo-progs \
+    python-setuptools python-virtualenv \
+    python-dev python3-dev cmake \
+    libtiff5-dev zlib1g-dev \
+    libcairo2-dev libjpeg62-turbo-dev libpango1.0-dev libgif-dev \
+    libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev \
+    python-tk python3-tk \
+    libharfbuzz-dev libfribidi-dev && apt-get clean
+
+# Make bash our shell
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# Add files required to bootstrap
+ADD catalog              /app/catalog
+ADD fxplanet             /app/fxplanet
+ADD Makefile             /app
+ADD manage               /app
+ADD manage.py            /app
+ADD requirements.txt     /app
+ADD requirements-dev.txt /app
+
+# Bootstrap. Needs setuptools installed in the virtualenv
+WORKDIR /app
+RUN virtualenv -p python3 env
+RUN source env/bin/activate && pip install -U setuptools
+RUN make
+
+RUN mkdir -p /app/fxplanet/static_collected
+
+EXPOSE 8000
+
+# Run each time when the container starts
+CMD source env/bin/activate && python manage.py migrate && python manage.py runserver 0.0.0.0:8000

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Examples:
 ./manage migrate
 ```
 
+## Docker quick-start
+
+* Ensure media files are in fxplanet/media
+* Ensure database dump is in top level directory as fxplanet.sql.gz
+* docker-compose up
 
 ## Helpful links
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '2'
+services:
+
+  postgres:
+    image: postgres:9
+    environment:
+      POSTGRES_DB: fxplanet
+      POSTGRES_USER: fxplanet
+      POSTGRES_PASSWORD: fxplanet
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      # The dump will be initialized on first start
+      - ./fxplanet.sql.gz:/docker-entrypoint-initdb.d/dump.sql.gz
+      # postgres does not recommend mounting the data dir. We just persist it as volume
+      - /var/lib/postgresql/data/pgdata
+
+  django:
+    # Build from Dockerfile
+    build: .
+    environment:
+      PYTHONUNBUFFERED: 1
+    # Ports to expose on localhost
+    ports:
+      - 8000:8000
+    # Mount working directions inside the container so we don't have to rebuild it
+    volumes:
+      - ./catalog:/app/catalog
+      - ./fxplanet:/app/fxplanet
+    # Let postgres run first
+    depends_on:
+      - postgres

--- a/fxplanet/settings.py
+++ b/fxplanet/settings.py
@@ -82,6 +82,10 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'fxplanet',
+        'USER': 'fxplanet',
+        'PASSWORD': 'fxplanet',
+        'HOST': 'postgres',
+        'PORT': '5432',
     }
 }
 


### PR DESCRIPTION
This PR adds a couple of configuration files for launching the project locally in a docker environment.

The updated settings.py file points django at database server running in another container.
if there is a way to actually set these defaults from env variables instead it would be more flexible.