### PR TITLE
Update docker-compose to add support for memcached

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
       # postgres does not recommend mounting the data dir. We just persist it as volume
       - /var/lib/postgresql/data/pgdata
 
+  memcached:
+    image: memcached:alpine
+
+
   django:
     # Build from Dockerfile
     build: .
@@ -25,7 +29,9 @@ services:
     # Mount working directions inside the container so we don't have to rebuild it
     volumes:
       - ./catalog:/app/catalog
+      - ./flatpagescustom:/app/flatpagescustom
       - ./fxplanet:/app/fxplanet
-    # Let postgres run first
+    # Let postgres and memcached run first
     depends_on:
+      - memcached
       - postgres

--- a/fxplanet/settings.py
+++ b/fxplanet/settings.py
@@ -61,7 +61,7 @@ MIDDLEWARE = [
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '127.0.0.1:11211',
+        'LOCATION': 'memcached:11211',
         'KEY_PREFIX': 'fxplanet_',
         'TIMEOUT': 600,
     }


### PR DESCRIPTION
Updates:

* docker-compose.yml

Adds memcached service as dependency of django service.
The memcached service will be available for django at memcached:11211.

* fxplanet/settings.py

Points django-memcached at memcached:11211