### PR TITLE
Restore pagination and breadcrumb links

### DIFF
--- a/catalog/views.py
+++ b/catalog/views.py
@@ -27,6 +27,7 @@ def download(request, slug):
 
 class LatestEffectsListView(ListView):
     model = Effect
+    paginate_by = 8
     template_name = 'latest.html'
     ordering = ('-created_at',)
 
@@ -59,9 +60,6 @@ class LatestEffectsListView(ListView):
 
 class EffectDetailView(DetailView):
     model = Effect
-
-    # def get_success_url(self):
-    #     return reverse('notes-list')
 
     def get_context_data(self, **kwargs):
         data = super(EffectDetailView, self).get_context_data(**kwargs)

--- a/fxplanet/templates/catalog/effect_detail.html
+++ b/fxplanet/templates/catalog/effect_detail.html
@@ -3,12 +3,14 @@
 
 {% block content %}
 
-<h2>Effects
+<h2>
+  <a href="{% url "latest-effects" %}">Effects</a>
+
   {% if object.category %}
-  {% if object.category.parent %}
-  &raquo; {{ object.category.parent.name }}
-  {% endif %}
-  &raquo; {{ object.category.name }}
+    {% if object.category.parent %}
+      &raquo; <a href="{% url "latest-effects-by-category" object.category.parent.pk %}">{{ object.category.parent.name }}</a>
+    {% endif %}
+    &raquo; <a href="{% url "latest-effects-by-category" object.category.pk %}">{{ object.category.name }}</a>
   {% endif %}
 
   &raquo; {{ object.name }}

--- a/fxplanet/templates/catalog/effect_list.html
+++ b/fxplanet/templates/catalog/effect_list.html
@@ -1,14 +1,17 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load staticfiles pagination %}
 
 {% block content %}
-<h2>Effects
-  {% if search %}&raquo; Search: {{ search.q }}{% endif %}
+<h2>
+  <a href="{% url "latest-effects" %}">Effects</a>
+
   {% if category %}
     {% if category.parent %}
-      &raquo; {{ category.parent.name }}
+      &raquo; <a href="{% url "latest-effects-by-category" category.parent.pk %}">{{ category.parent.name }}</a>
     {% endif %}
     &raquo; {{ category.name }}
+  {% else %}
+    {% if search and search.q %}&raquo; Search: {{ search.q }}{% endif %}
   {% endif %}
 </h2>
 
@@ -44,6 +47,25 @@
       </div>
 
     {% endif %}
+
+    {% if is_paginated %}
+    <nav class="text-center">
+      <ul class="pagination">
+        <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}">
+          <a class="page-link" {% if page_obj.has_previous %}href="?{% page_query_string page_obj.previous_page_number search %}"{% endif %}><i class="fa fa-arrow-left"></i></a>
+        </li>
+        {% for page in page_obj.paginator.page_range %}
+        <li class="page-item {% if page == page_obj.number %}active{% endif %}">
+          <a class="page-link" href="?{% page_query_string page search %}">{{ page }}</a>
+        </li>
+        {% endfor %}
+        <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}">
+          <a class="page-link" {% if page_obj.has_next %} href="?{% page_query_string page_obj.next_page_number search %}"{% endif %}><i class="fa fa-arrow-right"></i></a>
+        </li>
+      </ul>
+    </nav>
+    {% endif %}
+
   </div>
 
 {% endblock %}


### PR DESCRIPTION
Changes:

1. catalog/views.py

* restore paginate_by variable - 8 seems good fit for full-hd screen and matches with the landing page
* remove unused code

2. fxplanet/templates/catalog/effect_detail.html

* restore category links in breadcrumb

2. fxplanet/templates/catalog/effect_list.html

* restore category links in breadcrumb
* restore pagination